### PR TITLE
Search label deletion

### DIFF
--- a/src/Dono/Models/PersistableLabels.swift
+++ b/src/Dono/Models/PersistableLabels.swift
@@ -67,16 +67,16 @@ internal class PersistableLabels
     
     internal func deleteAt(position: Int) -> String
     {
-        let ret = self.labels.removeAtIndex(position);
+        let ret = labels.removeAtIndex(position);
         
-        self.saveLabels();
+        saveLabels()
         
         return ret;
     }
 
     internal func count() -> Int
     {
-        return self.labels.count;
+        return self.labels.count
     }
     
     internal func canonical(label: String) -> String

--- a/src/Dono/ViewControllers/LabelsViewController.swift
+++ b/src/Dono/ViewControllers/LabelsViewController.swift
@@ -111,12 +111,14 @@ class LabelsViewController: DonoViewController, UITableViewDataSource, UITableVi
         cell!.firstTrigger = 0.2;
 
         cell!.setSwipeGestureWithView(UIImageView(image: DonoViewController.DeleteSweepImage!), color: DonoViewController.Red, mode: .Exit, state: .State3, completionBlock: {[unowned self] (cell: MCSwipeTableViewCell!, state: MCSwipeTableViewCellState!, mode: MCSwipeTableViewCellMode!) -> Void in
-        
             let labelToDelete = self.resultSearchController.active ? self.filteredTableData[indexPath.row] : self.persistableLabels.getAt(indexPath.row)
+            
             guard let indexOfItemToDelete = self.persistableLabels.labels.indexOf(labelToDelete) else { return }
+            
             if self.resultSearchController.active {
                 self.filteredTableData.removeAtIndex(indexPath.row)
             }
+            
             self.persistableLabels.deleteAt(indexOfItemToDelete)
             self.updateTableView()
         })

--- a/src/Dono/ViewControllers/LabelsViewController.swift
+++ b/src/Dono/ViewControllers/LabelsViewController.swift
@@ -110,10 +110,14 @@ class LabelsViewController: DonoViewController, UITableViewDataSource, UITableVi
         cell!.defaultColor = DonoViewController.PrimaryColor
         cell!.firstTrigger = 0.2;
 
-        cell!.setSwipeGestureWithView(UIImageView(image: DonoViewController.DeleteSweepImage!), color: DonoViewController.Red, mode: .Exit, state: .State3, completionBlock: { (cell: MCSwipeTableViewCell!, state: MCSwipeTableViewCellState!, mode: MCSwipeTableViewCellMode!) -> Void in
-
-            self.persistableLabels.deleteAt(indexPath.row);
-
+        cell!.setSwipeGestureWithView(UIImageView(image: DonoViewController.DeleteSweepImage!), color: DonoViewController.Red, mode: .Exit, state: .State3, completionBlock: {[unowned self] (cell: MCSwipeTableViewCell!, state: MCSwipeTableViewCellState!, mode: MCSwipeTableViewCellMode!) -> Void in
+        
+            let labelToDelete = self.resultSearchController.active ? self.filteredTableData[indexPath.row] : self.persistableLabels.getAt(indexPath.row)
+            guard let indexOfItemToDelete = self.persistableLabels.labels.indexOf(labelToDelete) else { return }
+            if self.resultSearchController.active {
+                self.filteredTableData.removeAtIndex(indexPath.row)
+            }
+            self.persistableLabels.deleteAt(indexOfItemToDelete)
             self.updateTableView()
         })
         


### PR DESCRIPTION
The purpose of this pull request is to fix a bug with deleting labels when the search results controller is active.  

Basically this is just an indexing difference between the search results controller and the normal tableview.  Also, this manner of editing a tableview is pretty nonstandard, using the delegate method for ```editActionsForRowAtIndexpath``` might be a better way forward.